### PR TITLE
Add GHDL as plugin to Yosys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # Author(s): Pavel Benacek <pavel.benacek@gmail.com>
+#            Leuenberger Niklaus <https://github.com/NikLeberg>
 
 ARG UBUNTU_VERSION=22.04
 FROM ubuntu:$UBUNTU_VERSION AS base
@@ -13,14 +14,14 @@ ARG SBT_OPTS_DEFAULT="-Dsbt.override.build.repos=true -Dsbt.boot.directory=/sbt/
 ENV COURSIER_CACHE=$COURSIER_CACHE_DEFAULT
 ENV SBT_OPTS=$SBT_OPTS_DEFAULT
 
-ARG DEPS_RUNTIME="ca-certificates gnupg2 openjdk-17-jdk-headless ccache curl g++ gcc git libtcl8.6 python3 python3-pip python3-pip-whl libpython3-dev ssh locales make ghdl iverilog libboost1.74-dev"
+ARG DEPS_RUNTIME="ca-certificates gnupg2 openjdk-17-jdk-headless ccache curl g++ gcc git libtcl8.6 python3 python3-pip python3-pip-whl libpython3-dev ssh locales make libgnat-13 iverilog libboost1.74-dev"
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $DEPS_RUNTIME
 
 FROM base AS build-symbiyosys
 
 ENV PREFIX=/opt
-ARG DEPS_YOSYS="autoconf build-essential clang cmake libffi-dev libreadline-dev pkg-config tcl-dev unzip flex bison"
+ARG DEPS_YOSYS="autoconf build-essential clang cmake libffi-dev libreadline-dev pkg-config tcl-dev unzip flex bison gnat libz-dev"
 RUN apt-get install -y --no-install-recommends $DEPS_YOSYS
 
 ARG YOSYS_VERSION="yosys-0.28"
@@ -64,6 +65,26 @@ RUN git clone https://github.com/YosysHQ/sby.git SymbiYosys && \
     make PREFIX=$PREFIX -j$(nproc) install && \
     cd .. && \
     rm -Rf SymbiYosys
+
+ARG GHDL_VERSION="v4.1.0"
+RUN git clone https://github.com/ghdl/ghdl ghdl && \
+    cd ghdl && \
+    git checkout $GHDL_VERSION && \
+    mkdir build && \
+    cd build && \
+    ../configure --prefix=$PREFIX && \
+    make && \
+    make install && \
+    cd ../.. && \
+    rm -Rf ghdl
+
+ARG GHDL_PLUGIN_VERSION="0c4740a"
+RUN git clone https://github.com/ghdl/ghdl-yosys-plugin.git ghdl-yosys-plugin && \
+    cd ghdl-yosys-plugin && \
+    git reset $GHDL_PLUGIN_VERSION --hard && \
+    make YOSYS_PREFIX=$PREFIX install && \
+    cd .. && \
+    rm -Rf ghdl-yosys-plugin
 
 FROM base AS build-verilator
 


### PR DESCRIPTION
Add the [`ghdl-yosys-plugin`](https://github.com/ghdl/ghdl-yosys-plugin) to Yosys.

For reasoning, see https://github.com/SpinalHDL/SpinalHDL/pull/1429.

This also builds GHDL from source instead of pulling from apt.

I tested this in my own projects over at [`NikLeberg/container_builder`](https://github.com/NikLeberg/container_builder/pull/85). There I did update all the build arguments to the latest versions though:
```
UBUNTU_VERSION=24.04
YOSYS_VERSION=yosys-0.41
SOLVERS_PATH=snapshot-20240212/ubuntu-22.04-X64-bin.zip
BOOLECTOR_VERSION=3.2.3
SYMBIYOSYS_VERSION=yosys-0.41
GHDL_VERSION=v4.1.0
GHDL_PLUGIN_VERSION=0c4740a
MILL_VERSION=0.11.7
```
Not sure if this is required or wished for.